### PR TITLE
Allow passing streams to Writer classes

### DIFF
--- a/src/PcapngUtils/Pcap/PcapWriter.cs
+++ b/src/PcapngUtils/Pcap/PcapWriter.cs
@@ -41,6 +41,13 @@ namespace Haukcode.PcapngUtils.Pcap
             Initialize(new FileStream(path, FileMode.Create),sh);
         }
 
+        public PcapWriter(Stream stream, bool nanoseconds = false, bool reverseByteOrder = false)
+        {
+            CustomContract.Requires<ArgumentNullException>(stream != null, "stream cannot be null");
+            SectionHeader sh = SectionHeader.CreateEmptyHeader(nanoseconds, reverseByteOrder);
+            Initialize(stream, sh);
+        }
+
         public PcapWriter(string path, SectionHeader header)
         {
             CustomContract.Requires<ArgumentNullException>(!string.IsNullOrWhiteSpace(path), "path cannot be null or empty");
@@ -48,6 +55,14 @@ namespace Haukcode.PcapngUtils.Pcap
             CustomContract.Requires<ArgumentNullException>(header!=null, "SectionHeader cannot be null");
             
             Initialize(new FileStream(path, FileMode.Create),header);
+        }
+
+        public PcapWriter(Stream stream, SectionHeader header)
+        {
+            CustomContract.Requires<ArgumentNullException>(stream != null, "stream cannot be null");
+            CustomContract.Requires<ArgumentNullException>(header != null, "SectionHeader cannot be null");
+
+            Initialize(stream, header);
         }
 
          private void Initialize(Stream stream, SectionHeader header)

--- a/src/PcapngUtils/PcapNG/PcapNGWriter.cs
+++ b/src/PcapngUtils/PcapNG/PcapNGWriter.cs
@@ -49,6 +49,12 @@ namespace Haukcode.PcapngUtils.PcapNG
             Initialize(new FileStream(path, FileMode.Create), new List<HeaderWithInterfacesDescriptions>(){header}) ;
         }  
 
+        public PcapNGWriter(Stream stream, bool reverseByteOrder = false)
+        {
+            CustomContract.Requires<ArgumentNullException>(stream != null, "stream cannot be null");
+            HeaderWithInterfacesDescriptions header = HeaderWithInterfacesDescriptions.CreateEmptyHeadeWithInterfacesDescriptions(false);
+            Initialize(stream, new List<HeaderWithInterfacesDescriptions>() { header });
+        }
         public PcapNGWriter(string path, List<HeaderWithInterfacesDescriptions> headersWithInterface)
         {
             CustomContract.Requires<ArgumentNullException>(!string.IsNullOrWhiteSpace(path), "path cannot be null or empty");
@@ -59,6 +65,15 @@ namespace Haukcode.PcapngUtils.PcapNG
             CustomContract.Requires<ArgumentException>(headersWithInterface.Count >= 1, "headersWithInterface list is empty");
 
             Initialize(new FileStream(path, FileMode.Create), headersWithInterface);
+        }
+        public PcapNGWriter(Stream stream, List<HeaderWithInterfacesDescriptions> headersWithInterface)
+        {
+            CustomContract.Requires<ArgumentNullException>(stream != null, "stream cannot be null");
+            CustomContract.Requires<ArgumentNullException>(headersWithInterface != null, "headersWithInterface list cannot be null");
+
+            CustomContract.Requires<ArgumentException>(headersWithInterface.Count >= 1, "headersWithInterface list is empty");
+
+            Initialize(stream,  headersWithInterface);
         }
 
         private void Initialize(Stream stream, List<HeaderWithInterfacesDescriptions> headersWithInterface)


### PR DESCRIPTION
Hi Hakan
I've been using PcapngUtils since it was a .NET framework library and was delighted to find your .NET core port.
Since the original creator (ryrychj) isn't very responsive in github I'd like to submit this pull request to your fork.

This change allows us to pass streams to PcapNGWriter/PcapWriter and removes the files-only limitation (passing a path).
In particular, this can be used to pass a named pipe stream (which are used in Wireshark's extcap API)

Let me know if there're any issues or changes you want me to make.