### PR TITLE
Support multiple comments options

### DIFF
--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/AbstractBlockFactory.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/AbstractBlockFactory.cs
@@ -130,7 +130,7 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     Assert.AreEqual(interfaceBlock.InterfaceID, 1);
                     Assert.AreEqual(interfaceBlock.Timestamp.Seconds, 1427315514);
                     Assert.AreEqual(interfaceBlock.Timestamp.Microseconds, 468951);
-                    Assert.AreEqual(interfaceBlock.Options.Comment, "Counters provided by dumpcap");
+                    Assert.AreEqual(interfaceBlock.Options.Comments.Single(), "Counters provided by dumpcap");
                     Assert.AreEqual(interfaceBlock.Options.InterfaceDrop, 1);
                     Assert.AreEqual(interfaceBlock.Options.InterfaceReceived, 56);
                     Assert.AreEqual(interfaceBlock.Options.StartTime.Seconds, 1427315511);

--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/EnchantedPacketBlock.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/EnchantedPacketBlock.cs
@@ -50,7 +50,68 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     Assert.AreEqual(prePacketBlock.PacketLength, postPacketBlock.PacketLength);
                     Assert.AreEqual(prePacketBlock.PositionInStream, postPacketBlock.PositionInStream);
                     Assert.AreEqual(prePacketBlock.Seconds, postPacketBlock.Seconds);
-                    Assert.AreEqual(prePacketBlock.Options.Comment, postPacketBlock.Options.Comment);
+                    Assert.AreEqual(prePacketBlock.Options.Comments, postPacketBlock.Options.Comments);
+                    Assert.AreEqual(prePacketBlock.Options.DropCount, postPacketBlock.Options.DropCount);
+                    Assert.AreEqual(prePacketBlock.Options.Hash, postPacketBlock.Options.Hash);
+                    Assert.AreEqual(prePacketBlock.Options.PacketFlag, postPacketBlock.Options.PacketFlag);
+                }
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public static void EnhancedPacketBlock_ConvertToByteWithTwoComments_Test(bool reorder)
+        {
+            EnhancedPacketBlock prePacketBlock, postPacketBlock;
+            byte[] byteblock = {
+                0x06,0x00,0x00,0x00,0x94,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x38,0xE7,0x05,0x00,
+                0x78,0xE5,0x9C,0xAF,0x3E,0x00,0x00,0x00,0x3E,0x00,0x00,0x00,0x50,0x6F,0x0C,0x03,
+                0xC7,0x07,0xA8,0x47,0x4A,0x6E,0xCC,0xC3,0x08,0x00,0x45,0x00,0x00,0x30,0x9F,0x35,
+                0x40,0x00,0x80,0x06,0x00,0x00,0x0A,0x64,0x66,0x0C,0xAC,0x1C,0xC3,0x01,0x70,0x80,
+                0x11,0x67,0x53,0x67,0x60,0x3E,0x00,0x00,0x00,0x00,0x70,0x02,0xFA,0xF0,0xDF,0xB0,
+                0x00,0x00,0x02,0x04,0x05,0xB4,0x01,0x01,0x04,0x02,0x00,0x00,0x01,0x00,0x11,0x00,
+                0x54,0x68,0x65,0x20,0x46,0x69,0x72,0x73,0x74,0x20,0x43,0x6F,0x6D,0x6D,0x65,0x6E,
+                0x74,0x00,0x00,0x00,0x01,0x00,0x12,0x00,0x54,0x68,0x65,0x20,0x53,0x65,0x63,0x6F,
+                0x6E,0x64,0x20,0x43,0x6F,0x6D,0x6D,0x65,0x6E,0x74,0x00,0x00,0x00,0x00,0x00,0x00,
+                0x94,0x00,0x00,0x00,0x05,0x00,0x00,0x00,0x6C,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                0x38,0xE7,0x05,0x00,0x94,0x95,0xA2,0xAF,0x01,0x00,0x1C,0x00,0x43,0x6F,0x75,0x6E,
+                0x74,0x65,0x72,0x73,0x20,0x70,0x72,0x6F,0x76,0x69,0x64,0x65,0x64,0x20,0x62,0x79,
+                0x20,0x64,0x75,0x6D,0x70,0x63,0x61,0x70,0x02,0x00,0x08,0x00,0x38,0xE7,0x05,0x00,
+                0xDD,0xD8,0x96,0xAF,0x03,0x00,0x08,0x00,0x38,0xE7,0x05,0x00,0x94,0x95,0xA2,0xAF,
+                0x04,0x00,0x08,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x05,0x00,0x08,0x00,
+                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x6C,0x00,0x00,0x00
+            };
+            using (MemoryStream stream = new MemoryStream(byteblock))
+            {
+                using (BinaryReader binaryReader = new BinaryReader(stream))
+                {
+                    AbstractBlock block = AbstractBlockFactory.ReadNextBlock(binaryReader, false, null);
+                    Assert.IsNotNull(block);
+                    prePacketBlock = block as EnhancedPacketBlock;
+                    Assert.IsNotNull(prePacketBlock);
+                    byteblock = prePacketBlock.ConvertToByte(reorder, null);
+                }
+            }
+            using (MemoryStream stream = new MemoryStream(byteblock))
+            {
+                using (BinaryReader binaryReader = new BinaryReader(stream))
+                {
+                    AbstractBlock block = AbstractBlockFactory.ReadNextBlock(binaryReader, reorder, null);
+                    Assert.IsNotNull(block);
+                    postPacketBlock = block as EnhancedPacketBlock;
+                    Assert.IsNotNull(postPacketBlock);
+
+                    Assert.AreEqual(prePacketBlock.BlockType, postPacketBlock.BlockType);
+                    Assert.AreEqual(prePacketBlock.Data, postPacketBlock.Data);
+                    Assert.AreEqual(prePacketBlock.InterfaceID, postPacketBlock.InterfaceID);
+                    Assert.AreEqual(prePacketBlock.Microseconds, postPacketBlock.Microseconds);
+                    Assert.AreEqual(prePacketBlock.PacketLength, postPacketBlock.PacketLength);
+                    Assert.AreEqual(prePacketBlock.PositionInStream, postPacketBlock.PositionInStream);
+                    Assert.AreEqual(prePacketBlock.Seconds, postPacketBlock.Seconds);
+                    Assert.AreEqual(prePacketBlock.Options.Comments, postPacketBlock.Options.Comments);
+                    Assert.AreEqual(prePacketBlock.Options.Comments.Count, 2);
+                    Assert.AreEqual(prePacketBlock.Options.Comments[0], "The First Comment");
+                    Assert.AreEqual(prePacketBlock.Options.Comments[1], "The Second Comment");
                     Assert.AreEqual(prePacketBlock.Options.DropCount, postPacketBlock.Options.DropCount);
                     Assert.AreEqual(prePacketBlock.Options.Hash, postPacketBlock.Options.Hash);
                     Assert.AreEqual(prePacketBlock.Options.PacketFlag, postPacketBlock.Options.PacketFlag);

--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/InterfaceDescriptionBlock.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/InterfaceDescriptionBlock.cs
@@ -47,7 +47,7 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     Assert.AreEqual(prePacketBlock.SnapLength, postPacketBlock.SnapLength);
                     Assert.AreEqual(prePacketBlock.PositionInStream, postPacketBlock.PositionInStream);
 
-                    Assert.AreEqual(prePacketBlock.Options.Comment, postPacketBlock.Options.Comment);
+                    Assert.AreEqual(prePacketBlock.Options.Comments, postPacketBlock.Options.Comments);
                     Assert.AreEqual(prePacketBlock.Options.Description, postPacketBlock.Options.Description);
                     Assert.AreEqual(prePacketBlock.Options.EuiAddress, postPacketBlock.Options.EuiAddress);
                     Assert.AreEqual(prePacketBlock.Options.Filter, postPacketBlock.Options.Filter);

--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/InterfaceStatisticsBlock.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/InterfaceStatisticsBlock.cs
@@ -45,7 +45,7 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     Assert.AreEqual(preStatisticBlock.BlockType, postStatisticBlock.BlockType);
                     Assert.AreEqual(preStatisticBlock.InterfaceID, postStatisticBlock.InterfaceID);
                     Assert.AreEqual(preStatisticBlock.Timestamp, postStatisticBlock.Timestamp);
-                    Assert.AreEqual(preStatisticBlock.Options.Comment, postStatisticBlock.Options.Comment);
+                    Assert.AreEqual(preStatisticBlock.Options.Comments, postStatisticBlock.Options.Comments);
                     Assert.AreEqual(preStatisticBlock.Options.DeliveredToUser, postStatisticBlock.Options.DeliveredToUser);
                     Assert.AreEqual(preStatisticBlock.Options.EndTime, postStatisticBlock.Options.EndTime);
                     Assert.AreEqual(preStatisticBlock.Options.StartTime, postStatisticBlock.Options.StartTime);

--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/NameResolutionBlock.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/NameResolutionBlock.cs
@@ -57,7 +57,7 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     {
                         Assert.AreEqual(prePacketBlock.NameResolutionRecords[i], postPacketBlock.NameResolutionRecords[i]);
                     }
-                    Assert.AreEqual(prePacketBlock.Options.Comment, postPacketBlock.Options.Comment);
+                    Assert.AreEqual(prePacketBlock.Options.Comments, postPacketBlock.Options.Comments);
                     Assert.AreEqual(prePacketBlock.Options.DnsName, postPacketBlock.Options.DnsName);
                     Assert.AreEqual(prePacketBlock.Options.DnsIp4Addr, postPacketBlock.Options.DnsIp4Addr);
                     Assert.AreEqual(prePacketBlock.Options.DnsIp6Addr, postPacketBlock.Options.DnsIp6Addr);

--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/PacketBlock.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/PacketBlock.cs
@@ -51,7 +51,7 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     Assert.AreEqual(prePacketBlock.PacketLength, postPacketBlock.PacketLength);
                     Assert.AreEqual(prePacketBlock.PositionInStream, postPacketBlock.PositionInStream);
                     Assert.AreEqual(prePacketBlock.Seconds, postPacketBlock.Seconds);
-                    Assert.AreEqual(prePacketBlock.Options.Comment, postPacketBlock.Options.Comment);
+                    Assert.AreEqual(prePacketBlock.Options.Comments, postPacketBlock.Options.Comments);
                     Assert.AreEqual(prePacketBlock.Options.Hash, postPacketBlock.Options.Hash);
                     Assert.AreEqual(prePacketBlock.Options.PacketFlag, postPacketBlock.Options.PacketFlag);
                 }

--- a/src/PcapngUtils.Tests/PcapNG/BlockTypes/SectionHeaderBlock.cs
+++ b/src/PcapngUtils.Tests/PcapNG/BlockTypes/SectionHeaderBlock.cs
@@ -48,7 +48,7 @@ namespace Haukcode.PcapngUtils.PcapNG.BlockTypes
                     Assert.AreEqual(prePacketBlock.MinorVersion, postPacketBlock.MinorVersion);
                     Assert.AreEqual(prePacketBlock.SectionLength, postPacketBlock.SectionLength);
                     Assert.AreEqual(prePacketBlock.PositionInStream, postPacketBlock.PositionInStream);
-                    Assert.AreEqual(prePacketBlock.Options.Comment, postPacketBlock.Options.Comment);
+                    Assert.AreEqual(prePacketBlock.Options.Comments, postPacketBlock.Options.Comments);
                     Assert.AreEqual(prePacketBlock.Options.Hardware, postPacketBlock.Options.Hardware);
                     Assert.AreEqual(prePacketBlock.Options.OperatingSystem, postPacketBlock.Options.OperatingSystem);
                     Assert.AreEqual(prePacketBlock.Options.UserApplication, postPacketBlock.Options.UserApplication);

--- a/src/PcapngUtils.Tests/PcapNG/OptionTypes/EnchantedPacketOption.cs
+++ b/src/PcapngUtils.Tests/PcapNG/OptionTypes/EnchantedPacketOption.cs
@@ -22,7 +22,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {
             EnhancedPacketOption preOption = new EnhancedPacketOption();
             EnhancedPacketOption postOption;
-            preOption.Comment = "Test Comment";
+            preOption.Comments.Add("Test Comment");
             preOption.DropCount = 25;
             byte[] md5Hash = { 3, 87, 248, 225, 163, 56, 121, 102, 219, 226, 164, 68, 165, 51, 9, 177, 59 };
             preOption.Hash = new HashBlock(md5Hash);
@@ -37,7 +37,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
             }
 
             Assert.IsNotNull(postOption);
-            Assert.AreEqual(preOption.Comment, postOption.Comment);
+            Assert.AreEqual(preOption.Comments, postOption.Comments);
             Assert.AreEqual(preOption.DropCount, postOption.DropCount);
             Assert.AreEqual(preOption.Hash.Algorithm, postOption.Hash.Algorithm);
             Assert.AreEqual(preOption.Hash.Value, postOption.Hash.Value);

--- a/src/PcapngUtils.Tests/PcapNG/OptionTypes/InterfaceDescriptionOption.cs
+++ b/src/PcapngUtils.Tests/PcapNG/OptionTypes/InterfaceDescriptionOption.cs
@@ -23,7 +23,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {
             InterfaceDescriptionOption preOption = new InterfaceDescriptionOption();
             InterfaceDescriptionOption postOption;
-            preOption.Comment = "Test Comment";
+            preOption.Comments.Add("Test Comment");
             preOption.Description = "Test Description";
             preOption.EuiAddress = new byte[] { 0x00, 0x0A, 0xE6, 0xFF, 0xFE, 0x3E, 0xFD, 0xE1 };
             preOption.Filter = new byte[] { 5, 6, 7, 8 };
@@ -48,7 +48,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
             }
 
             Assert.IsNotNull(postOption);
-            Assert.AreEqual(preOption.Comment, postOption.Comment);
+            Assert.AreEqual(preOption.Comments, postOption.Comments);
             Assert.AreEqual(preOption.Description, postOption.Description);
             Assert.AreEqual(preOption.EuiAddress, postOption.EuiAddress);
             Assert.AreEqual(preOption.Filter, postOption.Filter);

--- a/src/PcapngUtils.Tests/PcapNG/OptionTypes/InterfaceStatisticsOption.cs
+++ b/src/PcapngUtils.Tests/PcapNG/OptionTypes/InterfaceStatisticsOption.cs
@@ -22,7 +22,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {
             InterfaceStatisticsOption preOption = new InterfaceStatisticsOption();
             InterfaceStatisticsOption postOption;
-            preOption.Comment = "Test Comment";
+            preOption.Comments.Add("Test Comment");
             preOption.DeliveredToUser = 25;
             preOption.EndTime = new TimestampHelper(new byte[] { 1, 0, 0, 0, 2, 0, 0, 0 }, false);
             preOption.StartTime = new TimestampHelper(new byte[] { 1, 0, 0, 3, 2, 0, 0, 4 }, false);
@@ -41,7 +41,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
             }
 
             Assert.IsNotNull(postOption);
-            Assert.AreEqual(preOption.Comment, postOption.Comment);
+            Assert.AreEqual(preOption.Comments, postOption.Comments);
             Assert.AreEqual(preOption.DeliveredToUser, postOption.DeliveredToUser);
             Assert.AreEqual(preOption.EndTime.Seconds, postOption.EndTime.Seconds);
             Assert.AreEqual(preOption.EndTime.Microseconds, postOption.EndTime.Microseconds);

--- a/src/PcapngUtils.Tests/PcapNG/OptionTypes/NameResolutionOption.cs
+++ b/src/PcapngUtils.Tests/PcapNG/OptionTypes/NameResolutionOption.cs
@@ -21,7 +21,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {
             NameResolutionOption preOption = new NameResolutionOption();
             NameResolutionOption postOption;
-            preOption.Comment = "Test Comment";
+            preOption.Comments.Add("Test Comment");
             preOption.DnsName = "Dns Name";
             preOption.DnsIp4Addr = new IPAddress(new byte[] { 127, 0, 0, 1 });
             preOption.DnsIp6Addr = new IPAddress(new byte[] { 0x20, 0x01, 0x0d, 0x0db, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x14, 0x28, 0x57, 0xab });
@@ -37,7 +37,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
             }
 
             Assert.IsNotNull(postOption);
-            Assert.AreEqual(preOption.Comment, postOption.Comment);
+            Assert.AreEqual(preOption.Comments, postOption.Comments);
             Assert.AreEqual(preOption.DnsName, postOption.DnsName);
             Assert.AreEqual(preOption.DnsIp4Addr, postOption.DnsIp4Addr);
             Assert.AreEqual(preOption.DnsIp6Addr, postOption.DnsIp6Addr);

--- a/src/PcapngUtils.Tests/PcapNG/OptionTypes/PacketOption.cs
+++ b/src/PcapngUtils.Tests/PcapNG/OptionTypes/PacketOption.cs
@@ -21,7 +21,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {
             PacketOption preOption = new PacketOption();
             PacketOption postOption;
-            preOption.Comment = "Test Comment";
+            preOption.Comments.Add("Test Comment");
             byte[] md5Hash = { 3, 87, 248, 225, 163, 56, 121, 102, 219, 226, 164, 68, 165, 51, 9, 177, 59 };
             preOption.Hash = new HashBlock(md5Hash);
             preOption.PacketFlag = new PacketBlockFlags(0xFF000000);
@@ -35,7 +35,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
             }
 
             Assert.IsNotNull(postOption);
-            Assert.AreEqual(preOption.Comment, postOption.Comment);
+            Assert.AreEqual(preOption.Comments, postOption.Comments);
             Assert.AreEqual(preOption.Hash.Algorithm, postOption.Hash.Algorithm);
             Assert.AreEqual(preOption.Hash.Value, postOption.Hash.Value);
             Assert.AreEqual(preOption.PacketFlag.Flag, postOption.PacketFlag.Flag);

--- a/src/PcapngUtils.Tests/PcapNG/OptionTypes/SectionHeaderOption.cs
+++ b/src/PcapngUtils.Tests/PcapNG/OptionTypes/SectionHeaderOption.cs
@@ -20,7 +20,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {
             SectionHeaderOption preOption = new SectionHeaderOption();
             SectionHeaderOption postOption;
-            preOption.Comment = "Test Comment";
+            preOption.Comments.Add("Test Comment");
             preOption.Hardware = "x86 Personal Computer";
             preOption.OperatingSystem = "Windows 7";
             preOption.UserApplication = "PcapngUtils";
@@ -34,7 +34,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
             }
 
             Assert.IsNotNull(postOption);
-            Assert.AreEqual(preOption.Comment, postOption.Comment);
+            Assert.AreEqual(preOption.Comments, postOption.Comments);
             Assert.AreEqual(preOption.Hardware, postOption.Hardware);
             Assert.AreEqual(preOption.OperatingSystem, postOption.OperatingSystem);
             Assert.AreEqual(preOption.UserApplication, postOption.UserApplication);

--- a/src/PcapngUtils/PcapNG/OptionTypes/EnhancedPacketOption.cs
+++ b/src/PcapngUtils/PcapNG/OptionTypes/EnhancedPacketOption.cs
@@ -26,9 +26,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
         #region fields & properies
         /// <summary>
-        /// A UTF-8 string containing a comment that is associated to the current block.
+        /// A list of UTF-8 strings containing comments that are associated to the current block.
         /// </summary>
-        public string Comment
+        public List<string> Comments
         {
             get;
             set;
@@ -69,9 +69,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region ctor
-        public EnhancedPacketOption(string Comment = null, PacketBlockFlags PacketFlag = null, long? DropCount = null, HashBlock Hash = null)
+        public EnhancedPacketOption(List<string> Comments = null, PacketBlockFlags PacketFlag = null, long? DropCount = null, HashBlock Hash = null)
         {
-            this.Comment = Comment;
+            this.Comments = Comments ?? new List<string>();
             this.PacketFlag = PacketFlag;
             this.DropCount = DropCount;
             this.Hash = Hash;
@@ -94,7 +94,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
                         switch (item.Key)
                         {
                             case (ushort)EnhancedPacketOptionCode.CommentCode:
-                                option.Comment = UTF8Encoding.UTF8.GetString(item.Value);
+                                option.Comments.Add(UTF8Encoding.UTF8.GetString(item.Value));
                                 break;
                             case (ushort)EnhancedPacketOptionCode.PacketFlagCode:
                                 if (item.Value.Length == 4)
@@ -134,11 +134,14 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
             List<byte> ret = new List<byte>();
 
-            if (Comment != null)
+            if (Comments != null)
             {
-                byte[] comentValue = UTF8Encoding.UTF8.GetBytes(Comment);
-                if (comentValue.Length <= UInt16.MaxValue)
-                    ret.AddRange(ConvertOptionFieldToByte((ushort)EnhancedPacketOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                foreach (string comment in Comments)
+                {
+                    byte[] comentValue = UTF8Encoding.UTF8.GetBytes(comment);
+                    if (comentValue.Length <= UInt16.MaxValue)
+                        ret.AddRange(ConvertOptionFieldToByte((ushort)EnhancedPacketOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                }
             }
 
             if (PacketFlag != null)

--- a/src/PcapngUtils/PcapNG/OptionTypes/InterfaceDescriptionOption.cs
+++ b/src/PcapngUtils/PcapNG/OptionTypes/InterfaceDescriptionOption.cs
@@ -166,9 +166,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
         #region fields & properies
         /// <summary>
-        /// A UTF-8 string containing a comment that is associated to the current block.
+        /// A list of UTF-8 strings containing comments that are associated to the current block.
         /// </summary>
-        public string Comment
+        public List<string> Comments
         {
             get;
             set;
@@ -314,12 +314,12 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region ctor
-        public InterfaceDescriptionOption(string Comment = null, string Name = null, string Description = null, IPAddress IPv4Address_v4 = null,
+        public InterfaceDescriptionOption(List<string> Comments = null, string Name = null, string Description = null, IPAddress IPv4Address_v4 = null,
             IPAddress_v6 IPv6Address = null, PhysicalAddress MacAddress = null, byte[] EuiAddress = null, long? Speed = null, byte? TimestampResolution = 6,
             int? TimeZone = null, byte[] Filter = null, string OperatingSystem = null, byte? FrameCheckSequence = null, long? TimeOffsetSeconds = null) 
         {
             CustomContract.Requires<ArgumentException>(EuiAddress == null || EuiAddress.Length == 8, "Invalid EuiAddress length. (Should be 8 bytes)");               
-            this.Comment = Comment;
+            this.Comments = Comments ?? new List<string>();
             this.Name = Name;
             this.Description = Description;
             this.IPv4Address = IPv4Address;
@@ -352,7 +352,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
                         switch (item.Key)
                         {
                             case (ushort)InterfaceDescriptionOptionCode.CommentCode:
-                                option.Comment = UTF8Encoding.UTF8.GetString(item.Value);
+                                option.Comments.Add(UTF8Encoding.UTF8.GetString(item.Value));
                                 break;
                             case (ushort)InterfaceDescriptionOptionCode.NameCode:
                                 option.Name = UTF8Encoding.UTF8.GetString(item.Value);
@@ -443,11 +443,14 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         { 
             List<byte> ret = new List<byte>();
 
-            if (Comment != null)
+            if (Comments != null)
             {
-                byte[] comentValue = UTF8Encoding.UTF8.GetBytes(Comment);
-                if (comentValue.Length <= UInt16.MaxValue)
-                    ret.AddRange(ConvertOptionFieldToByte((ushort)InterfaceDescriptionOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                foreach (string comment in Comments)
+                {
+                    byte[] comentValue = UTF8Encoding.UTF8.GetBytes(comment);
+                    if (comentValue.Length <= UInt16.MaxValue)
+                        ret.AddRange(ConvertOptionFieldToByte((ushort)InterfaceDescriptionOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                }
             }
 
             if (Name != null)

--- a/src/PcapngUtils/PcapNG/OptionTypes/InterfaceStatisticsOption.cs
+++ b/src/PcapngUtils/PcapNG/OptionTypes/InterfaceStatisticsOption.cs
@@ -30,9 +30,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
         #region fields & properies
         /// <summary>
-        /// A UTF-8 string containing a comment that is associated to the current block.
+        /// A list of UTF-8 strings containing comments that are associated to the current block.
         /// </summary>
-        public string Comment
+        public List<string> Comments
         {
             get;
             set;
@@ -114,10 +114,10 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region ctor
-        public InterfaceStatisticsOption(string Comment = null, TimestampHelper StartTime = null, TimestampHelper EndTime = null, long? InterfaceReceived = null,
+        public InterfaceStatisticsOption(List<string> Comments = null, TimestampHelper StartTime = null, TimestampHelper EndTime = null, long? InterfaceReceived = null,
             long? InterfaceDrop = null, long? FilterAccept = null, long? SystemDrop = null, long? DeliveredToUser =null) 
         {
-            this.Comment = Comment;
+            this.Comments = Comments ?? new List<string>();
             this.StartTime = StartTime;
             this.EndTime = EndTime;
             this.InterfaceReceived = InterfaceReceived;
@@ -145,7 +145,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
                         switch (item.Key)
                         {
                             case (ushort)InterfaceStatisticsOptionCode.CommentCode:
-                                option.Comment = UTF8Encoding.UTF8.GetString(item.Value);
+                                option.Comments.Add(UTF8Encoding.UTF8.GetString(item.Value));
                                 break;
                             case (ushort)InterfaceStatisticsOptionCode.StartTimeCode:
                                 if (item.Value.Length == 8)
@@ -209,11 +209,14 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {    
             List<byte> ret = new List<byte>();
 
-            if (Comment != null)
+            if (Comments != null)
             {
-                byte[] comentValue = UTF8Encoding.UTF8.GetBytes(Comment);
-                if (comentValue.Length <= UInt16.MaxValue)
-                    ret.AddRange(ConvertOptionFieldToByte((ushort)InterfaceStatisticsOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                foreach (string comment in Comments)
+                {
+                    byte[] comentValue = UTF8Encoding.UTF8.GetBytes(comment);
+                    if (comentValue.Length <= UInt16.MaxValue)
+                        ret.AddRange(ConvertOptionFieldToByte((ushort)InterfaceStatisticsOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                }
             }
 
             if (StartTime != null)

--- a/src/PcapngUtils/PcapNG/OptionTypes/NameResolutionOption.cs
+++ b/src/PcapngUtils/PcapNG/OptionTypes/NameResolutionOption.cs
@@ -24,10 +24,11 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region fields & properies
+
         /// <summary>
-        /// A UTF-8 string containing a comment that is associated to the current block.
+        /// A list of UTF-8 strings containing comments that are associated to the current block.
         /// </summary>
-        public string Comment
+        public List<string> Comments
         {
             get;
             set;
@@ -80,12 +81,12 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region ctor
-        public NameResolutionOption(string Comment = null, string DnsName = null, IPAddress DnsIp4Addr = null, IPAddress DnsIp6Addr = null)
+        public NameResolutionOption(List<string> Comments = null, string DnsName = null, IPAddress DnsIp4Addr = null, IPAddress DnsIp6Addr = null)
         {
             CustomContract.Requires<ArgumentException>(DnsIp4Addr == null || DnsIp4Addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork,   "dnsIp4Addr is not AddressFamily.InterNetwork");
             CustomContract.Requires<ArgumentException>(DnsIp6Addr == null || DnsIp6Addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6, "dnsIp6Addr is not AddressFamily.InterNetworkV6");
                     
-            this.Comment = Comment;
+            this.Comments = Comments ?? new List<string>();
             this.DnsName = DnsName;
             this.dnsIp4Addr = DnsIp4Addr;
             this.dnsIp6Addr = DnsIp6Addr;
@@ -108,7 +109,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
                         switch (item.Key)
                         {
                             case (ushort)NameResolutionOptionCode.CommentCode:
-                                option.Comment = UTF8Encoding.UTF8.GetString(item.Value);
+                                option.Comments.Add(UTF8Encoding.UTF8.GetString(item.Value));
                                 break;
                             case (ushort)NameResolutionOptionCode.DnsNameCode:
                                 option.DnsName = UTF8Encoding.UTF8.GetString(item.Value);
@@ -144,11 +145,13 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         {               
             List<byte> ret = new List<byte>();
 
-            if (Comment != null)
+            if (Comments != null)
             {
-                byte[] comentValue = UTF8Encoding.UTF8.GetBytes(Comment);
-                if (comentValue.Length <= UInt16.MaxValue)
-                    ret.AddRange(ConvertOptionFieldToByte((ushort)NameResolutionOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                foreach (string comment in Comments) {
+                    byte[] comentValue = UTF8Encoding.UTF8.GetBytes(comment);
+                    if (comentValue.Length <= UInt16.MaxValue)
+                        ret.AddRange(ConvertOptionFieldToByte((ushort)NameResolutionOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                }
             }
 
             if (DnsName != null)

--- a/src/PcapngUtils/PcapNG/OptionTypes/PacketOption.cs
+++ b/src/PcapngUtils/PcapNG/OptionTypes/PacketOption.cs
@@ -24,9 +24,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
         #region fields & properies
         /// <summary>
-        /// A UTF-8 string containing a comment that is associated to the current block.
+        /// A list of UTF-8 strings containing comments that are associated to the current block.
         /// </summary>
-        public string Comment
+        public List<string> Comments
         {
             get;
             set;
@@ -58,9 +58,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region ctor
-        public PacketOption(string Comment = null, PacketBlockFlags PacketFlag = null, HashBlock Hash = null)
+        public PacketOption(List<string> Comments = null, PacketBlockFlags PacketFlag = null, HashBlock Hash = null)
         {
-            this.Comment = Comment;
+            this.Comments = Comments ?? new List<string>();
             this.PacketFlag = PacketFlag;
             this.Hash = Hash;
         }
@@ -82,7 +82,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
                         switch (item.Key)
                         {
                             case (ushort)PacketOptionCode.CommentCode:
-                                option.Comment = UTF8Encoding.UTF8.GetString(item.Value);
+                                option.Comments.Add(UTF8Encoding.UTF8.GetString(item.Value));
                                 break;
                             case (ushort)PacketOptionCode.PacketFlagCode: 
                                 if (item.Value.Length == 4)
@@ -116,11 +116,14 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
             List<byte> ret = new List<byte>();
 
-            if (Comment != null)
+            if (Comments != null)
             {
-                byte[] comentValue = UTF8Encoding.UTF8.GetBytes(Comment);
-                if (comentValue.Length <= UInt16.MaxValue)
-                    ret.AddRange(ConvertOptionFieldToByte((ushort)PacketOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                foreach (var comment in Comments)
+                {
+                    byte[] comentValue = UTF8Encoding.UTF8.GetBytes(comment);
+                    if (comentValue.Length <= UInt16.MaxValue)
+                        ret.AddRange(ConvertOptionFieldToByte((ushort)PacketOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                }
             }
 
             if (PacketFlag != null)

--- a/src/PcapngUtils/PcapNG/OptionTypes/SectionHeaderOption.cs
+++ b/src/PcapngUtils/PcapNG/OptionTypes/SectionHeaderOption.cs
@@ -24,9 +24,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
         #region fields & properies
         /// <summary>
-        /// A UTF-8 string containing a comment that is associated to the current block.
+        /// A list of UTF-8 strings containing comments that are associated to the current block.
         /// </summary>
-        public string Comment
+        public List<string> Comments
         {
             get;
             set;
@@ -61,9 +61,9 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
         #endregion
 
         #region ctor
-        public SectionHeaderOption(string Comment = null, string Hardware = null, string OperatingSystem = null, string UserApplication = null)
+        public SectionHeaderOption(List<string> Comments = null, string Hardware = null, string OperatingSystem = null, string UserApplication = null)
         {
-            this.Comment = Comment;
+            this.Comments = Comments ?? new List<string>();
             this.Hardware = Hardware;
             this.OperatingSystem = OperatingSystem;
             this.UserApplication = UserApplication;
@@ -86,7 +86,7 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
                         switch (item.Key)
                         {
                             case (ushort)SectionHeaderOptionCode.CommentCode:
-                                option.Comment = UTF8Encoding.UTF8.GetString(item.Value);
+                                option.Comments.Add(UTF8Encoding.UTF8.GetString(item.Value));
                                 break;
                             case (ushort)SectionHeaderOptionCode.HardwareCode:
                                 option.Hardware = UTF8Encoding.UTF8.GetString(item.Value);
@@ -117,11 +117,14 @@ namespace Haukcode.PcapngUtils.PcapNG.OptionTypes
 
             List<byte> ret = new List<byte>();
 
-            if (Comment != null)
+            if (Comments != null)
             {
-                byte[] comentValue = UTF8Encoding.UTF8.GetBytes(Comment);
-                if (comentValue.Length <= UInt16.MaxValue)
-                    ret.AddRange(ConvertOptionFieldToByte((ushort)SectionHeaderOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                foreach (var comment in Comments)
+                {
+                    byte[] comentValue = UTF8Encoding.UTF8.GetBytes(comment);
+                    if (comentValue.Length <= UInt16.MaxValue)
+                        ret.AddRange(ConvertOptionFieldToByte((ushort)SectionHeaderOptionCode.CommentCode, comentValue, reverseByteOrder, ActionOnException));
+                }
             }
 
             if (Hardware != null)


### PR DESCRIPTION
pcapng specifications allow multiple occurrences of the 'comment' option within the 'Options' are of any bock